### PR TITLE
Improve scikit-learn compatibility for `CleanTransformer` + tests

### DIFF
--- a/cleantext/sklearn.py
+++ b/cleantext/sklearn.py
@@ -68,7 +68,13 @@ class CleanTransformer(TransformerMixin, BaseEstimator):
         self.replace_with_punct = replace_with_punct
         self.lang = lang
 
-    def fit(self, X: Any):
+    def fit(self, X: Any, y=None):
+        """
+        This method is defined for compatibility. It does nothing.
+        """
+        return self
+
+    def partial_fit(self, X: Any, y=None):
         """
         This method is defined for compatibility. It does nothing.
         """
@@ -89,3 +95,14 @@ class CleanTransformer(TransformerMixin, BaseEstimator):
             return X.apply(lambda text: clean(text, **self.get_params()))
         else:
             return list(map(lambda text: clean(text, **self.get_params()), X))
+
+    def get_feature_names_out(self, feature_names_out=None):
+        """
+        For compatibility with scikit-learn Pipeline objects.
+        This transformer will only return one column, which is ``'Clean Text``.
+        Args:
+            feature_names_out: Defined for compatibility with scikit-learn.
+        Returns:
+            list[str]: List with one element (i.e. The cleaned text column).
+        """
+        return ["Clean Text"]

--- a/tests/test_clean_transformer.py
+++ b/tests/test_clean_transformer.py
@@ -1,7 +1,6 @@
 try:
     from cleantext.sklearn import CleanTransformer
     import pandas as pd
-
     import pytest
 
     transformer = CleanTransformer()
@@ -25,5 +24,12 @@ try:
         assert transformer.get_params()["no_line_breaks"]
         assert transformer.get_params()["no_digits"]
 
+    def test_get_feature_names_out():
+        feature_names = transformer.get_feature_names_out()
+        assert feature_names == ["Clean Text"]
+
+    def test_fit():
+        transformer.fit(["sample1", "sample2"], [0, 1])
+        transformer.partial_fit(["sample1", "sample2"])
 except ImportError:
     pass


### PR DESCRIPTION
First of all, thank you for building and open-sourcing this! It has been very helpful for us at @CrowdCent. 

We ran into some issues when trying to use `CleanTransformer` as a component. These are:
1. `fit` should have `y=None` defined for compatbility so supervised training can be done where `CleanTransformer` is a component in a `Pipeline`.
2. It is standard since `scikit-learn==1.1` to define `get_feature_names_out` ([Source](https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_1_0.html?highlight=release+notes#get-feature-names-out-available-in-all-transformers)).

I've implemented these and wrote some accompanying tests. Would be happy to discuss any changes.