### PR TITLE
add no_emoji attribute in  README.md for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ clean("some input",
     no_digits=False,                # replace all digits with a special token
     no_currency_symbols=False,      # replace all currency symbols with a special token
     no_punct=False,                 # remove punctuations
+    no_emoji=False,                 # remove emojis
     replace_with_punct="",          # instead of removing punctuations you may replace them
     exceptions=None,                # list of regex patterns to preserve verbatim
     replace_with_code="<CODE>",


### PR DESCRIPTION
I have found when working on this package has another similar package cleantext. In order to differentiate between them I added `no_emoji` to be clear for anyone is exists 