### PR TITLE
fix: support replacing URLs mixed with CJK characters (#15)

### DIFF
--- a/cleantext/clean.py
+++ b/cleantext/clean.py
@@ -127,6 +127,14 @@ def replace_urls(text, replace_with="<URL>"):
     """
     Replace all URLs in ``text`` str with ``replace_with`` str.
     """
+    CJK = r'[\u4e00-\u9fff\u3040-\u30ff]'  # CJK Unicode ranges: \u4e00-\u9fff (Chinese/Japanese Kanji), \u3040-\u30ff (Hiragana/Katakana)
+    B = r'[^\s，。？！；：、（）【】「」“”‘’\)\]\}]'
+    text = re.sub(
+        r'(' + B + r'*?' + CJK + B + r'*?https?://' + B + r'*|' +
+        B + r'*?https?://' + B + r'*?' + CJK + B + r'*)',
+        lambda m: ''.join(re.findall(CJK, m.group(1))) + replace_with,
+        text
+    )
     return constants.URL_REGEX.sub(replace_with, text)
 
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -30,6 +30,30 @@ def test_replace_urls():
         assert cleantext.replace_urls(text, "*URL*") == proc_text
 
 
+def test_replace_CJK_urls():
+    texts = [
+        [
+            "请点击http://www.example.com查看内容",
+            "请点击查看内容*URL*",
+        ],
+        [
+            "http://www.tie你好ba.com",
+            "你好*URL*",
+        ],
+        [
+            "こんにちはhttp://example.com/テスト",
+            "こんにちはテスト*URL*",
+        ],
+        [
+            "前部http://leetcode.com後ろにある",
+            "前部後ろにある*URL*",
+        ],
+    ]
+
+    for text, proc_text in texts:
+        assert cleantext.replace_urls(text, "*URL*") == proc_text
+
+
 email_addresses = [
     "mustermann@fh-aachen.de",
     "mustermann(at)fh-aachen.de",


### PR DESCRIPTION
Hi,

This PR aims to resolve issue #15 regarding **URLs mixed with CJK (Chinese, Japanese, Korean) characters**.

Since CJK languages do not use spaces between words, URLs frequently attach directly to surrounding text (e.g., _`你好http://example.com`_). The current strict boundary checks miss these cases.

To fix this, I added a preprocessing step inside the `replace_urls` function. It identifies continuous blocks containing both `http(s)://` and CJK characters, extracts the CJK text, and replaces the URL structure with the placeholder. 

Because this preprocessing strictly requires a CJK character to trigger, pure English strings without spaces remain unaffected with near-zero performance overhead. Standard English URL processing is also completely unchanged.

All relevant tests passed. Please let me know if anything needs adjustment. Thanks!