### PR TITLE
fix: apply safe static-analysis cleanups across package

### DIFF
--- a/benchmarks/bench_clean_texts.py
+++ b/benchmarks/bench_clean_texts.py
@@ -15,7 +15,7 @@ import time
 # Suppress noisy warnings from worker processes (e.g. unidecode fallback)
 logging.disable(logging.WARNING)
 
-from cleantext import clean, clean_texts
+from cleantext import clean_texts  # noqa: E402
 
 # ── sample data ──────────────────────────────────────────────────────────────
 
@@ -32,16 +32,16 @@ SAMPLE_TEXTS = [
     "»Yóù àré     rïght &lt;3!«  🤔 🙈 emoji test 👩🏾\u200d🎓",
 ]
 
-KWARGS = dict(
-    no_urls=True,
-    no_emails=True,
-    no_phone_numbers=True,
-    no_ip_addresses=True,
-    no_file_paths=True,
-    no_code=True,
-    no_currency_symbols=True,
-    lang="de",
-)
+KWARGS = {
+    "no_urls": True,
+    "no_emails": True,
+    "no_phone_numbers": True,
+    "no_ip_addresses": True,
+    "no_file_paths": True,
+    "no_code": True,
+    "no_currency_symbols": True,
+    "lang": "de",
+}
 
 
 def build_corpus(n):
@@ -50,7 +50,7 @@ def build_corpus(n):
     return SAMPLE_TEXTS * repeats + SAMPLE_TEXTS[:remainder]
 
 
-def bench(corpus, n_jobs, warmup=False):
+def bench(corpus, n_jobs, _warmup=False):
     """Time a single clean_texts() call and return elapsed seconds."""
     start = time.perf_counter()
     result = clean_texts(corpus, n_jobs=n_jobs, **KWARGS)
@@ -91,7 +91,7 @@ def main():
         seq = clean_texts(corpus, n_jobs=1, **KWARGS)
         par = clean_texts(corpus, n_jobs=-1, **KWARGS)
         assert seq == par, "MISMATCH between sequential and parallel results!"
-        print(f"  ✓ sequential == parallel output verified")
+        print("  ✓ sequential == parallel output verified")
         print()
 
 

--- a/cleantext/clean.py
+++ b/cleantext/clean.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import sys
+from contextlib import suppress
 from functools import partial
 from multiprocessing import Pool
 from unicodedata import category
@@ -60,10 +61,8 @@ def fix_bad_unicode(text, normalization="NFC"):
             with three periods
     """
     # trying to fix backslash-replaced strings (via https://stackoverflow.com/a/57192592/4028896)
-    try:
+    with suppress(Exception):
         text = text.encode("latin", "backslashreplace").decode("unicode-escape")
-    except Exception:
-        pass
 
     return fix_text(text, normalization=normalization)
 
@@ -180,8 +179,7 @@ def replace_currency_symbols(text, replace_with="<CUR>"):
         for k, v in constants.CURRENCIES.items():
             text = text.replace(k, v)
         return text
-    else:
-        return constants.CURRENCY_REGEX.sub(replace_with, text)
+    return constants.CURRENCY_REGEX.sub(replace_with, text)
 
 
 def replace_punct(text, replace_with=" "):
@@ -474,42 +472,42 @@ def clean_texts(
     texts = list(texts)
     n_jobs = _resolve_n_jobs(n_jobs)
 
-    kwargs = dict(
-        fix_unicode=fix_unicode,
-        to_ascii=to_ascii,
-        lower=lower,
-        normalize_whitespace=normalize_whitespace,
-        no_line_breaks=no_line_breaks,
-        strip_lines=strip_lines,
-        keep_two_line_breaks=keep_two_line_breaks,
-        no_code=no_code,
-        no_urls=no_urls,
-        no_emails=no_emails,
-        no_phone_numbers=no_phone_numbers,
-        no_ip_addresses=no_ip_addresses,
-        no_file_paths=no_file_paths,
-        no_numbers=no_numbers,
-        no_digits=no_digits,
-        no_currency_symbols=no_currency_symbols,
-        no_punct=no_punct,
-        no_emoji=no_emoji,
-        replace_with_code=replace_with_code,
-        replace_with_url=replace_with_url,
-        replace_with_email=replace_with_email,
-        replace_with_phone_number=replace_with_phone_number,
-        replace_with_ip_address=replace_with_ip_address,
-        replace_with_file_path=replace_with_file_path,
-        replace_with_number=replace_with_number,
-        replace_with_digit=replace_with_digit,
-        replace_with_currency_symbol=replace_with_currency_symbol,
-        replace_with_punct=replace_with_punct,
-        lang=lang,
-        exceptions=exceptions,
-    )
+    kwargs = {
+        "fix_unicode": fix_unicode,
+        "to_ascii": to_ascii,
+        "lower": lower,
+        "normalize_whitespace": normalize_whitespace,
+        "no_line_breaks": no_line_breaks,
+        "strip_lines": strip_lines,
+        "keep_two_line_breaks": keep_two_line_breaks,
+        "no_code": no_code,
+        "no_urls": no_urls,
+        "no_emails": no_emails,
+        "no_phone_numbers": no_phone_numbers,
+        "no_ip_addresses": no_ip_addresses,
+        "no_file_paths": no_file_paths,
+        "no_numbers": no_numbers,
+        "no_digits": no_digits,
+        "no_currency_symbols": no_currency_symbols,
+        "no_punct": no_punct,
+        "no_emoji": no_emoji,
+        "replace_with_code": replace_with_code,
+        "replace_with_url": replace_with_url,
+        "replace_with_email": replace_with_email,
+        "replace_with_phone_number": replace_with_phone_number,
+        "replace_with_ip_address": replace_with_ip_address,
+        "replace_with_file_path": replace_with_file_path,
+        "replace_with_number": replace_with_number,
+        "replace_with_digit": replace_with_digit,
+        "replace_with_currency_symbol": replace_with_currency_symbol,
+        "replace_with_punct": replace_with_punct,
+        "lang": lang,
+        "exceptions": exceptions,
+    }
 
     worker = partial(clean, **kwargs)
 
-    if n_jobs == 1 or len(texts) == 0:
+    if n_jobs == 1 or not texts:
         return [worker(t) for t in texts]
 
     with Pool(processes=min(n_jobs, len(texts))) as pool:

--- a/cleantext/constants.py
+++ b/cleantext/constants.py
@@ -23,7 +23,7 @@ CURRENCIES = {
     "₴": "UAH",
     "₹": "INR",
 }
-CURRENCY_REGEX = re.compile("({})+".format("|".join(re.escape(c) for c in CURRENCIES.keys())))
+CURRENCY_REGEX = re.compile("({})+".format("|".join(re.escape(c) for c in CURRENCIES)))
 
 PUNCT_TRANSLATE_UNICODE = dict.fromkeys(
     (i for i in range(sys.maxunicode) if unicodedata.category(chr(i)).startswith("P")),

--- a/cleantext/sklearn.py
+++ b/cleantext/sklearn.py
@@ -2,7 +2,7 @@
 Pipeline transformer for scikit-learn to clean text
 """
 
-from typing import Any, Union
+from typing import Any
 
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -82,19 +82,19 @@ class CleanTransformer(TransformerMixin, BaseEstimator):
         self.lang = lang
         self.exceptions = exceptions
 
-    def fit(self, X: Any, y=None):
+    def fit(self, X: Any, _y=None):
         """
         This method is defined for compatibility. It does nothing.
         """
         return self
 
-    def partial_fit(self, X: Any, y=None):
+    def partial_fit(self, X: Any, _y=None):
         """
         This method is defined for compatibility. It does nothing.
         """
         return self
 
-    def transform(self, X: Union[list[str], pd.Series]) -> Union[list[str], pd.Series]:
+    def transform(self, X: list[str] | pd.Series) -> list[str] | pd.Series:
         """
         Normalize various aspects of each item in raw text array-like.
         Args:
@@ -105,12 +105,12 @@ class CleanTransformer(TransformerMixin, BaseEstimator):
         """
         if not (isinstance(X, list) or isinstance(X, pd.Series)):
             raise ValueError("The input must be a list or pd.Series")
+        params = self.get_params()
         if isinstance(X, pd.Series):
-            return X.apply(lambda text: clean(text, **self.get_params()))
-        else:
-            return list(map(lambda text: clean(text, **self.get_params()), X))
+            return X.apply(lambda text: clean(text, **params))
+        return [clean(text, **params) for text in X]
 
-    def get_feature_names_out(self, feature_names_out=None):
+    def get_feature_names_out(self, _feature_names_out=None):
         """
         For compatibility with scikit-learn Pipeline objects.
         This transformer will only return one column, which is ``'Clean Text``.

--- a/cleantext/specials.py
+++ b/cleantext/specials.py
@@ -135,7 +135,7 @@ def save_replace(text, lang, back=False):
     )
     for pattern, target in possibilities:
         if back:
-            text = text.replace(escape_sequence + target + escape_sequence, pattern)
+            text = text.replace(f"{escape_sequence}{target}{escape_sequence}", pattern)
         else:
-            text = text.replace(pattern, escape_sequence + target + escape_sequence)
+            text = text.replace(pattern, f"{escape_sequence}{target}{escape_sequence}")
     return text

--- a/cleantext/utils.py
+++ b/cleantext/utils.py
@@ -2,8 +2,10 @@
 Generic text processing functions.
 """
 
+from collections.abc import Iterable
 
-def remove_substrings(text, to_replace, replace_with=""):
+
+def remove_substrings(text: str, to_replace: str | Iterable[str], replace_with: str = "") -> str:
     """
     Remove (or replace) substrings from a text.
     Args:

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -191,8 +191,8 @@ def test_fix_bad_unicode():
     text = "and install a \\u2018new\\u2019 society in their"  # and install a ‘new’ society in their
     assert cleantext.fix_bad_unicode(text) == "and install a 'new' society in their"
 
-    assert "všetko" == cleantext.fix_bad_unicode("všetko")
-    assert "Všetko" == cleantext.fix_bad_unicode("Všetko")
+    assert cleantext.fix_bad_unicode("všetko") == "všetko"
+    assert cleantext.fix_bad_unicode("Všetko") == "Všetko"
 
 
 def test_zero_digits():

--- a/tests/test_clean_transformer.py
+++ b/tests/test_clean_transformer.py
@@ -1,4 +1,6 @@
-try:
+from contextlib import suppress
+
+with suppress(ImportError):
     import pandas as pd
     import pytest
 
@@ -32,5 +34,3 @@ try:
     def test_fit():
         transformer.fit(["sample1", "sample2"], [0, 1])
         transformer.partial_fit(["sample1", "sample2"])
-except ImportError:
-    pass


### PR DESCRIPTION
## What

While reviewing the codebase with static analysis, I found several safe, mechanical improvements that align with your existing ruff configuration and CI. This PR applies a **sample** of those fixes — not a full cleanup.

Our analysis found **114 format/lint issues** and about **99 refactoring opportunities** across the reviewed scope. Security scans were clean; Python duplication is ~5.8% (mostly shared parameter lists between `clean()` and `CleanTransformer`); `clean()` has elevated cyclomatic complexity (rank C). This pull request touches **8 files** with roughly **136 line changes** and is not a complete format or refactor pass.

## Changes

- **`cleantext/clean.py`**: use `contextlib.suppress` for optional unicode repair; simplify `replace_currency_symbols` control flow; use dict literal for kwargs forwarding; idiomatic empty-list check in `clean_texts`.
- **`cleantext/sklearn.py`**: modern union type hints; list comprehension in `transform`; prefix unused sklearn API parameters with `_`.
- **`cleantext/constants.py`**: iterate `CURRENCIES` directly instead of `.keys()`.
- **`cleantext/specials.py`**, **`cleantext/utils.py`**: minor string/format and type-hint improvements.
- **`benchmarks/bench_clean_texts.py`**: remove unused import; dict literal for kwargs; noqa for intentional post-`logging.disable` import.
- **`tests/`**: pytest-style assert ordering; `contextlib.suppress` for optional sklearn/pandas tests.

## Verification

- [x] `poetry run ruff check cleantext/ tests/ benchmarks/` — pass
- [x] `poetry run ruff format --check cleantext/ tests/ benchmarks/` — pass
- [x] `poetry run pytest` — 70 passed, 3 skipped

<details>
<summary>Other findings (not in this example PR)</summary>

| area | finding | note |
| --- | --- | --- |
| Duplication | ~5.8% Python duplication (`clean` ↔ `clean_texts` / `CleanTransformer` params) | follow-up refactor |
| Complexity | `clean()` cyclomatic complexity 20 (rank C) | defer — needs design |
| Dead code | `remove_substrings` unused; `ACRONYM_REGEX` unused | may be public API — confirm |
| Dependencies | Poetry-only `pyproject.toml`; deptry noise on optional sklearn/scipy | defer PEP 621 migration |
| Lint | many FBT002 boolean positional args in `clean()` signature | API-stable — defer |

</details>

---
*Review summary produced with [ShipGate](https://github.com/inquilabee/shipgate) — a policy-first quality orchestrator that runs linters, formatters, security scanners, and refactor checks from one catalog. This PR used `check` + `refactor check --strict` to find issues; [docs](https://inquilabee.github.io/shipgate/).*

Made with [Cursor](https://cursor.com)